### PR TITLE
Set I18n.locale explicitly.

### DIFF
--- a/lib/js_locale_helper.rb
+++ b/lib/js_locale_helper.rb
@@ -2,6 +2,7 @@ module JsLocaleHelper
 
   def self.output_locale(locale, translations = nil)
     locale_str = locale.to_s
+    I18n.locale = locale_str
 
     # load default translations
     translations ||= YAML::load(File.open("#{Rails.root}/config/locales/client.#{locale_str}.yml"))


### PR DESCRIPTION
Set I18n.locale explicitly.  Generated files are independent from system or user locale.

JSのロケールファイルをコンパイルする時に、I18nで使われるローケールを明示的に指定するように変更しました。
